### PR TITLE
Allow only self-hosted renovate to operate here

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,7 +4,15 @@
   "extends": [
     "config:best-practices",
     "github>grafana/sm-renovate//presets/grafana.json5",
+    ":disableDependencyDashboard",
   ],
+
+  // This is needed in order to prevent Renovate bot and/or MendRenovate from
+  // trying to run alongside the renovate app. The GitHub Action uses a wrapper
+  // script to pass `--enable` on the command line, which overrides this
+  // setting.
+  "enabled": false,
+
   "customManagers": [
     {
       // Update renovate version in GHA action YAMLs.

--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,5 @@
+{
+	"remediateSettings": {
+		"enableRenovate": false
+	}
+}

--- a/actions/renovate/action.yaml
+++ b/actions/renovate/action.yaml
@@ -33,11 +33,18 @@ runs:
         private-key: ${{ env.GRAFANA_RENOVATE_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
 
+    - name: find wrapper path
+      id: find-wrapper
+      shell: bash
+      run: |
+        echo "path=${GITHUB_ACTION_PATH}/renovate" >> "${GITHUB_OUTPUT}"
+
     - name: Self-hosted Renovate
       uses: renovatebot/github-action@e3a862510f27d57a380efb11f0b52ad7e8dbf213 # v41.0.6
       with:
         renovate-version: ${{ inputs.renovate-version }}
         token: ${{ steps.app-token.outputs.token }}
+        docker-cmd-file: ${{ steps.find-wrapper.outputs.path }}
       env:
         LOG_LEVEL: debug
         RENOVATE_DRY_RUN: ${{ inputs.dry-run }}

--- a/actions/renovate/renovate
+++ b/actions/renovate/renovate
@@ -1,0 +1,22 @@
+#!/bin/sh
+#
+# This scripts exists to pass `--enabled` to renovate on the command line.
+#
+# This is necessary because renovate app and MendRenovate are stubborn
+# (surprise!) and they keep trying to run if they get access to the repository
+# and they find a configuration file. In order to disable that, the
+# configuration file needs to _disable_ renovate, and the only way to enable it
+# back, beyond where renovate app and MendRenovate are able to see it, is to pass
+# the `--enabled` flag on the command line.
+#
+# The renovate github action takes a `docker-cmd-file` parameter that specifies
+# a *file* to copy into the container where renovate is going to run, and it's
+# used as the command to run in the container.
+#
+# This is that file.
+#
+# Rube Goldberg would be proud.
+
+set -x
+
+renovate --enabled --force-cli


### PR DESCRIPTION
renovate app and MendRenovate are stubborn (surprise!) and they keep trying to run if they get access to the repository and they find a configuration file.

Add the necessary countermeasures to prevent that. Yes, countermeasures. At this point renovate feels like something you have to fight against and not something you work with.