### PR TITLE
feat: set `GOPRIVATE` to allow renovate to fetch private grafana repos

### DIFF
--- a/actions/renovate/action.yaml
+++ b/actions/renovate/action.yaml
@@ -38,9 +38,12 @@ runs:
       with:
         renovate-version: ${{ inputs.renovate-version }}
         token: ${{ steps.app-token.outputs.token }}
+        # Default filter, plus GOPRIVATE.
+        env-regex: "^(?:RENOVATE_\\w+|LOG_LEVEL|GITHUB_COM_TOKEN|NODE_OPTIONS|AWS_TOKEN|GOPRIVATE)$"
       env:
         LOG_LEVEL: debug
         RENOVATE_DRY_RUN: ${{ inputs.dry-run }}
         RENOVATE_PLATFORM: github
         RENOVATE_REPOSITORIES: ${{ github.repository }}
         RENOVATE_USERNAME: GrafanaRenovateBot
+        GOPRIVATE: github.com/grafana # Allows fetching private dependencies.


### PR DESCRIPTION
According to `@arve` [here](https://raintank-corp.slack.com/archives/C0162C1K9E1/p1741330669598929?thread_ts=1741249741.016339&cid=C0162C1K9E1) this is enough to allow this functionality.

The `env-regex` shenanigan is needed as the renovate action implements a filter of env vars that it passes to the container that actually runs renovate (for, I guess, security reasons).