### PR TITLE
feat: renovate: allow running from the current branch for validation

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -22,3 +22,4 @@ jobs:
         uses: ./actions/renovate
         with:
           dry-run: "${{ github.event_name == 'pull_request' }}"
+          use-current-branch: "${{ github.event_name == 'pull_request' }}"

--- a/actions/renovate/action.yaml
+++ b/actions/renovate/action.yaml
@@ -2,8 +2,14 @@ name: Self-hosted Renovate
 description: Run renovate
 
 inputs:
+  use-current-branch:
+    description: |-
+      Run renovate off the branch for which this GitHub Action was invoked, instead of the default branch.
+      Must be used with dry-run.
+    required: false
+    default: "false"
   dry-run:
-    description: "Run Renovate in dry-run mode"
+    description: "Run Renovate in dry-run mode."
     required: false
     default: "false"
   renovate-version:
@@ -17,6 +23,19 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Check options
+      shell: bash
+      run: |-
+        if [[ "${{ inputs.use-current-branch }}" = "true" ]] && [[ "${{ inputs.dry-run }}" != "true" ]]; then
+          echo "::error title=Renovate action misconfigured::Refusing to run off the current branch without dry-run"
+          exit 1
+        fi
+
+        if [[ "${{ inputs.use-current-branch }}" = "true" ]] && [[ "${{ github.event_name }}" != "pull_request" ]]; then
+          echo "::error title=Renovate action misconfigured::use-current-branch should only be used in pull_request events."
+          exit 1
+        fi
+
     - name: retrieve secrets
       id: get-secrets
       uses: grafana/shared-workflows/actions/get-vault-secrets@94c84e6a44383130eaba3ed16f1c3ae667ab6925
@@ -46,4 +65,10 @@ runs:
         RENOVATE_PLATFORM: github
         RENOVATE_REPOSITORIES: ${{ github.repository }}
         RENOVATE_USERNAME: GrafanaRenovateBot
+        # https://docs.renovatebot.com/configuration-options/#usebasebranchconfig
+        RENOVATE_USE_BASE_BRANCH_CONFIG: ${{ inputs.use-current-branch && 'merge' || 'none' }}
+        # If dry-run is set and this is a PR event, run renovate off the branch being PR'd.
+        # https://docs.renovatebot.com/configuration-options/#basebranches
+        # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context
+        RENOVATE_BASE_BRANCHES: ${{ inputs.use-current-branch && github.head_ref || '' }}
         GOPRIVATE: github.com/grafana # Allows fetching private dependencies.


### PR DESCRIPTION
Following @d0ugal's suggestion, it would be useful to allow repos to run renovate in dry-run mode for PRs, as a way to sanity-check changes to renovate config.

This PR does exactly that: It adds an `use-current-branch` input to the action, which can be set by users to achieve this. When set, it will configure renovate to run off the branch that is being PR'd.

A small inline script is added to prevent misconfigurations, which will:
- Error out if `use-current-branch` is being specified but `dry-run` is not set to true
- Error out if `use-current-branch` is set for events that are not `pull_request`, as in those events there is no base branch to test.