### PR TITLE
presets/sm: add automerge rules for GHA, Go and Containers

### DIFF
--- a/presets/synthetic-monitoring.json5
+++ b/presets/synthetic-monitoring.json5
@@ -14,6 +14,45 @@
   "prConcurrentLimit": 10,
   "branchConcurrentLimit": 10,
   "packageRules": [
+    // Automerge rules
+    {
+      // Official and grafana GitHub Actions
+      "matchManagers": [
+        "github-actions",
+      ],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "matchPackageNames": [
+        "actions/**", // Official actions.
+        "grafana/**" // First-party actions.
+      ],
+      "automerge": true,
+    },
+    {
+      // First-party and stdlib go packages
+      "matchManagers": [
+        "gomod",
+      ],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "matchPackageNames": [
+        "go", // Toolchain
+        "golang.org/x/**", // Stdlib-but-not-stdlib
+        "github.com/grafana/**", // First-party libraries
+      ],
+      "automerge": true,
+    },
+    {
+      // First-party container images
+      "matchDatasources": [ // Match datasource instead of manager, as the Docker DS is widely used in regex managers.
+        "docker",
+      ],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "matchPackageNames": [
+        "ghcr.io/grafana/**",
+        "grafana/**",
+      ],
+      "automerge": true,
+    },
+    // End of automerge rules.
     {
       // go.mod digest updates are very frequent, so we allow them only on monday mornings.
       "matchManagers": [


### PR DESCRIPTION
This commit adds a first iteration of automerge rules for a restricted subset of packages and ecosystems.

Specifically, this change will cause renovate to enable automerge via GitHub for:
- Official and first-party GitHub Actions
- Toolchain, first-party, and `golang.org/x/` Go packages
- First-party container images

Where "first-party" means "Grafana".

In all cases, automerge will only be enabled for minor, patch, and digest type updates, never for majors.

This rules will cause renovate to _request_ GitHub to automerge the PRs, but it is not sufficient for the automerge to happen. For that, two other requirements must be met:
- The PR must be approved by a reviewer with write access (which may be the auto-approver bot, if enabled)
- The PR must pass all CI/CD checks